### PR TITLE
Add contents and references for an ODG demo instance

### DIFF
--- a/.github/workflows/update-odg-instance-cfg.yaml
+++ b/.github/workflows/update-odg-instance-cfg.yaml
@@ -1,0 +1,79 @@
+name: Update Demo ODG Instance Configuration
+
+on:
+  workflow_dispatch:
+    inputs:
+      bootstrapping-version:
+        type: string
+        required: true
+
+jobs:
+  update-odg-instance-cfg:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: gardener/cc-utils/.github/actions/kubernetes-auth@master
+        with:
+          server: https://api.odg-pre-prod.garden-ci.shoot.live.k8s-hana.ondemand.com
+          audience: open-delivery-gear
+          kubeconfig-path: /tmp/kubeconfig.yaml
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
+        with:
+          oci-image-reference: europe-docker.pkg.dev/gardener-project
+      - name: Update ODG Instance Configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pip3 install \
+            mako
+
+          component_name=ocm.software/ocm-gear/delivery-service
+          component_version=${{ inputs.bootstrapping-version }}
+
+          echo ">>> Retrieving OCM component descriptor"
+
+          python3 -m ocm download component-descriptor \
+            --component "${component_name}:${component_version}" \
+            --ocm-repository "europe-docker.pkg.dev/gardener-project/releases" \
+            -o /tmp/component-descriptor.yaml
+
+          bootstrapping_helm_oci_ref=$(yq eval '.component.resources[] | select(.name=="bootstrapping" and .type | test("helmChart")) | .access.imageReference' /tmp/component-descriptor.yaml)
+
+          echo ">>> Templating value files for Helm charts"
+
+          mako-render demo-cluster/bootstrapping/values.yaml.tpl \
+            --var 'blackduck_ctp_url=${{ vars.BLACKDUCK_CTP_URL }}' \
+            --var 'blackduck_foss_url=${{ vars.BLACKDUCK_FOSS_URL }}' \
+            --output-file demo-cluster/bootstrapping/values.yaml
+
+          mako-render demo-cluster/bootstrapping/secrets.yaml.tpl \
+            --var 'bdba_token=${{ secrets.BDBA_TOKEN }}' \
+            --var 'bdba_url=${{ vars.BDBA_URL }}' \
+            --var 'blackduck_ctp_token=${{ secrets.BLACKDUCK_CTP_TOKEN }}' \
+            --var 'blackduck_ctp_url=${{ vars.BLACKDUCK_CTP_URL }}' \
+            --var 'blackduck_foss_token=${{ secrets.BLACKDUCK_FOSS_TOKEN }}' \
+            --var 'blackduck_foss_url=${{ vars.BLACKDUCK_FOSS_URL }}' \
+            --var 'delivery_db_password=${{ secrets.DELIVERY_DB_PASSWORD }}' \
+            --var 'github_app_private_key=${{ secrets.APP_PRIVATE_KEY }}' \
+            --var 'oauth_cfg_client_secret=${{ secrets.OAUTH_CFG_CLIENT_SECRET }}' \
+            --var 'signing_cfg_private_key=${{ secrets.SIGNING_CFG_PRIVATE_KEY }}' \
+            --var 'signing_cfg_public_key=${{ secrets.SIGNING_CFG_PUBLIC_KEY }}' \
+            --output-file demo-cluster/bootstrapping/secrets.yaml
+
+          export KUBECONFIG=/tmp/kubeconfig.yaml
+
+          echo ">>> Installing bootstrapping Helm chart ${bootstrapping_helm_oci_ref}"
+
+          helm upgrade bootstrapping "oci://${bootstrapping_helm_oci_ref}" \
+            --namespace odg-demo \
+            --values demo-cluster/bootstrapping/values.yaml \
+            --values demo-cluster/bootstrapping/secrets.yaml \
+            --install \
+            --wait
+
+          echo ">>> Installation finished successfully"
+          echo "Installation finished successfully" >> ${GITHUB_STEP_SUMMARY}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The project is under neutral governance by the [NeoNephos Foundation](https://ne
 [![OpenSSF Baseline](https://www.bestpractices.dev/projects/12270/baseline)](https://www.bestpractices.dev/projects/12270)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/open-component-model/open-delivery-gear/badge)](https://scorecard.dev/viewer/?uri=github.com/open-component-model/open-delivery-gear)
 
+> [!TIP]
+> Check out the [live ODG Demo playground](https://delivery-dashboard.demo.ci.gardener.cloud)
+
 ## Index
 
 - [What Is It?](#what-is-it)
@@ -62,6 +65,10 @@ End users can work with findings and delivery insights either through the Delive
 
 ## Getting Started
 
+To get a feel for ODG before setting it up yourself, visit the [Demo Playground](https://delivery-dashboard.demo.ci.gardener.cloud).
+It provides a live instance of ODG connected to real data, so you can explore OCM components, findings, and the overall user experience without any installation required.
+
+- [🚧 Demo Playground](https://delivery-dashboard.demo.ci.gardener.cloud)
 - [Local Setup using Kind](https://github.com/open-component-model/delivery-service/blob/master/local-setup/local-setup.md)
 - [Standalone installation using Helm](https://github.com/open-component-model/delivery-service/tree/master/charts)
 - [K8s ODG Operator](https://github.com/open-component-model/delivery-service/tree/master/odg_operator)

--- a/demo-cluster/bootstrapping/secrets.yaml.tpl
+++ b/demo-cluster/bootstrapping/secrets.yaml.tpl
@@ -1,0 +1,63 @@
+secrets:
+  bdba:
+    primary:
+      api_url: ${bdba_url}
+      group_ids:
+        - 2907
+      token: '${bdba_token}'
+  blackduck:
+    ctp:
+      api_url: ${blackduck_ctp_url}
+      group_id: 86cb71af-4bc8-4fbe-beed-4e5731625620
+      token: '${blackduck_ctp_token}'
+    foss:
+      api_url: ${blackduck_foss_url}
+      group_id: f199b865-2b0f-412a-bc11-a190b8e2ee02
+      token: '${blackduck_foss_token}'
+  delivery-db:
+    primary:
+      username: postgres
+      password: '${delivery_db_password}'
+  github-app:
+    github-com:
+      api_url: https://api.github.com
+      app_id: 1725627
+      mappings:
+        - installation_id: 79146296
+          org: open-component-model
+      private_key: |
+% for line in github_app_private_key.splitlines():
+        ${line}
+% endfor
+  oauth-cfg:
+    github-com:
+      name: GitHub
+      type: github
+      api_url: https://api.github.com
+      client_id: Iv23lilcEx1MzFcsEsNC
+      client_secret: '${oauth_cfg_client_secret}'
+      role_bindings:
+        - roles:
+            - admin
+          subjects:
+            - name: open-component-model/odg-maintainers
+              type: github-team
+        - roles:
+            - writer
+          subjects:
+            - name: open-delivery-gear
+              type: github-app
+            - name: open-component-model
+              type: github-org
+  signing-cfg:
+    primary:
+      id: 517c9ea5-b84c-4b33-9c89-3f4e6d13720b
+      algorithm: RS256
+      private_key: |
+% for line in signing_cfg_private_key.splitlines():
+        ${line}
+% endfor
+      public_key: |
+% for line in signing_cfg_public_key.splitlines():
+        ${line}
+% endfor

--- a/demo-cluster/bootstrapping/values.yaml.tpl
+++ b/demo-cluster/bootstrapping/values.yaml.tpl
@@ -1,0 +1,417 @@
+extensions_cfg:
+  defaults:
+    delivery_dashboard_url: https://delivery-dashboard.demo.ci.gardener.cloud
+    delivery_service_url: https://delivery-service.demo.ci.gardener.cloud
+  access_manager:
+    enabled: True
+  artefact_enumerator:
+    components:
+      - component_name: ocm.software/ocmcli
+  bdba:
+    mappings:
+      - prefix: ''
+        group_id: 2907
+  blackduck:
+    mappings:
+      - prefix: ''
+        group_id_bdba: 2907
+        targets:
+          - group_id: 86cb71af-4bc8-4fbe-beed-4e5731625620
+            host: ${blackduck_ctp_url}
+          - group_id: f199b865-2b0f-412a-bc11-a190b8e2ee02
+            host: ${blackduck_foss_url}
+            distribution_mode_overwrite: SAAS
+    label_rules:
+      - name: ctp-instance
+        selector:
+          host: ${blackduck_ctp_url}
+      - name: foss-instance
+        selector:
+          host: ${blackduck_foss_url}
+  cache_manager:
+    prefill_function_caches:
+      components:
+        - component_name: ocm.software/ocmcli
+  clamav:
+    mappings:
+      - prefix: ''
+  crypto:
+    mappings:
+      - prefix: ''
+        standards:
+          - name: FIPS
+            version: 140-3
+            ref:
+              path: odg/crypto_defaults.yaml
+        libraries:
+          - ref:
+              path: odg/crypto_defaults.yaml
+  ghas:
+    github_instances:
+      - hostname: github.com
+        orgs:
+          - open-component-model
+  osid:
+    enabled: True
+  responsibles:
+    rules:
+      - name: ocmcli
+        filters:
+          - type: component-filter
+            include_component_names:
+              - ocm.software/ocmcli
+        strategies:
+          - type: static-responsibles
+            responsibles:
+              - type: githubTeam
+                github_hostname: github.com
+                teamname: open-component-model/maintainers
+        assignee_mode: overwrite
+  sast:
+    enabled: True
+
+findings:
+  - type: finding/crypto
+    categorisations:
+      - id: false-positive
+        display_name: False Positive
+        value: 0
+        rescoring: manual
+      - id: security-irrelevant
+        display_name: Security Irrelevant
+        value: 0
+        rescoring: manual
+      - id: compliant
+        display_name: Compliant
+        value: 0
+        rescoring: manual
+        selector:
+          ratings:
+            - compliant
+      - id: maybe-standard-compliant
+        display_name: Maybe Compliant
+        value: 2
+        allowed_processing_time: 90
+        rescoring: manual
+        selector:
+          ratings:
+            - maybe-compliant
+      - id: not-standard-compliant
+        display_name: Not Compliant
+        value: 8
+        allowed_processing_time: 30
+        rescoring: manual
+        selector:
+          ratings:
+            - not-compliant
+    filter:
+      - semantics: include
+        artefact_kind: resource
+  - type: finding/ghas
+    categorisations:
+      - id: pattern-edited
+        display_name: Pattern Edited
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+        selector:
+          resolutions:
+            - pattern_edited
+      - id: false-positive
+        display_name: False Positive
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+        selector:
+          resolutions:
+            - false_positive
+      - id: revoked
+        display_name: Revoked
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+        selector:
+          resolutions:
+            - revoked
+      - id: wont-fix
+        display_name: Won't Fix
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+        selector:
+          resolutions:
+            - wont_fix
+      - id: used-in-tests
+        display_name: Used In Tests
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+        selector:
+          resolutions:
+            - used_in_tests
+      - id: secret-found
+        display_name: Secret Found
+        value: 2
+        allowed_processing_time: 0
+        rescoring: manual
+        selector:
+          resolutions:
+            - null
+    filter:
+      - semantics: include
+        artefact_kind: source
+  - type: finding/license
+    categorisations:
+      - id: false-positive
+        display_name: False Positive
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+      - id: violation
+        display_name: Violation
+        value: 16
+        allowed_processing_time: 0
+        rescoring: manual
+        selector:
+          license_names:
+            - sleepycat
+    filter:
+      - semantics: include
+        artefact_kind: resource
+  - type: finding/malware
+    categorisations:
+      - id: false-positive
+        display_name: False Positive
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+      - id: scanner-limitation
+        display_name: Scanner-Limitation
+        value: 16
+        allowed_processing_time: 0
+        selector:
+          malware_names:
+            - Heuristics.Limits.Exceeded.*
+      - id: BLOCKER
+        display_name: Found
+        value: 16
+        allowed_processing_time: 0
+        rescoring: manual
+        selector:
+          malware_names:
+            - .*
+    filter:
+      - semantics: include
+        artefact_kind: resource
+  - type: finding/osid
+    categorisations:
+      - id: empty-os-id
+        display_name: Empty OS ID
+        value: -1
+        allowed_processing_time: ~
+        selector:
+          status:
+            - emptyOsId
+      - id: no-branch-info
+        display_name: No Branch Info
+        value: -1
+        allowed_processing_time: ~
+        selector:
+          status:
+            - noBranchInfo
+      - id: no-release-info
+        display_name: No Release Info
+        value: -1
+        allowed_processing_time: ~
+        selector:
+          status:
+            - noReleaseInfo
+      - id: unable-to-compare-version
+        display_name: Unable to Compare Version
+        value: -1
+        allowed_processing_time: ~
+        selector:
+          status:
+            - unableToCompareVersion
+      - id: up-to-date
+        display_name: Up to Date
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+      - id: false-positive
+        display_name: False-Positive
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+      - id: distroless
+        display_name: Distroless
+        value: 0
+        allowed_processing_time: ~
+        rescoring: manual
+        selector:
+          status:
+            - distroless
+      - id: postpone
+        display_name: Postpone
+        value: 1
+        allowed_processing_time: input
+        rescoring: manual
+      - id: one-or-more-patchlevel-behind
+        display_name: One or more Patchlevel behind
+        value: 2
+        allowed_processing_time: ~
+        rescoring: manual
+        selector:
+          status:
+            - patchlevelBehind
+      - id: eol
+        display_name: Branch no longer supported
+        value: 8
+        allowed_processing_time: 360
+        rescoring: manual
+        selector:
+          status:
+            - branchReachedEol
+    filter:
+      - semantics: include
+        artefact_kind: resource
+  - type: finding/sast
+    default_scope: single
+    categorisations:
+      - id: other
+        display_name: Other
+        value: 0
+        rescoring: manual
+      - id: no-linting-required
+        display_name: No SAST scans required
+        value: 0
+        rescoring: manual
+      - id: manual-linting
+        display_name: Manual SAST scans done
+        value: 0
+        rescoring: manual
+      - id: missing-linting
+        display_name: Missing SAST scan
+        value: 16
+        allowed_processing_time: 0
+        rescoring:
+          - automatic
+          - manual
+        selector:
+          sub_types:
+            - local-linting
+    filter:
+      - semantics: include
+        artefact_kind: source
+    reuse_discovery_date:
+      enabled: False
+  - type: finding/vulnerability
+    rescoring_ruleset:
+      cfg_name: gardener
+      ref:
+        path: odg/defaults.yaml
+    categorisations:
+      - id: NONE
+        display_name: Not Exploitable / Accept
+        value: 0 # required to be able to import triages made in BDBA
+        rescoring: manual
+      - id: postpone
+        display_name: Postpone
+        value: 1
+        allowed_processing_time: input
+        rescoring: manual
+      - id: LOW
+        display_name: Low
+        value: 1
+        allowed_processing_time: 120
+        rescoring: [manual, automatic]
+        selector:
+          cve_score_range:
+            min: 0.0
+            max: 3.9
+      - id: MEDIUM
+        display_name: Medium
+        value: 2
+        allowed_processing_time: 90
+        rescoring: [manual, automatic]
+        selector:
+          cve_score_range:
+            min: 4.0
+            max: 6.9
+      - id: HIGH
+        display_name: High
+        value: 4
+        allowed_processing_time: 30
+        rescoring: manual
+        selector:
+          cve_score_range:
+            min: 7.0
+            max: 8.9
+      - id: CRITICAL
+        display_name: Critical
+        value: 8
+        allowed_processing_time: 30
+        rescoring: manual
+        selector:
+          cve_score_range:
+            min: 9.0
+            max: 10.0
+    filter:
+      - semantics: include
+        artefact_kind: resource
+
+features_cfg:
+  specialComponents:
+    - id: bd545620-3e40-4c7e-aa39-8ef565047c9f
+      name: ocm.software/ocmcli
+      displayName: OCM CLI
+      type: OCM
+      version: greatest
+      icon: home
+      releasePipelineUrl: https://github.com/open-component-model/ocm/actions/workflows/release.yaml
+      currentVersion:
+        source:
+          type: github
+          repo: github.com/open-component-model/ocm
+          relpath:
+            - VERSION
+  sprints:
+    sprint_name_pattern: '%Y-week-%W'
+    start_date: '2026-01-01'
+    offset: 0
+    cycles: 0
+    meta:
+      offsets:
+        - display_name: Deployment
+          name: deployment
+          offset_days: 0
+        - display_name: Release Decision
+          name: release_decision
+          offset_days: 0
+        - display_name: Pre-Prod Freeze
+          name: pre_prod_freeze
+          offset_days: -3
+  upgradePRs: True
+
+ocm_repo_mappings:
+  - type: virtual
+    name: <auto>
+    selectors:
+      - version_filter_overwrite: semver_releases
+  - repository: europe-docker.pkg.dev/gardener-project/releases
+  - repository: ghcr.io/open-component-model/ocm
+    prefixes:
+      - ocm.software/ocmcli
+
+profiles:
+  - name: OCM
+    finding_types:
+      - finding/crypto
+      - finding/ghas
+      - finding/license
+      - finding/malware
+      - finding/osid
+      - finding/sast
+      - finding/vulnerability
+    special_component_ids:
+      - bd545620-3e40-4c7e-aa39-8ef565047c9f

--- a/demo-cluster/odg.yaml
+++ b/demo-cluster/odg.yaml
@@ -1,0 +1,22 @@
+apiVersion: open-delivery-gear.ocm.software/v1
+kind: ODG
+metadata:
+  finalizers:
+    - open-delivery-gear.ocm.software/odg-clean-up
+  name: odg-demo
+  namespace: delivery-modg
+spec:
+  context:
+    base_url: demo.ci.gardener.cloud
+    target_namespace: odg-demo
+  extensions:
+    - bdba
+    - blackduck
+    - crypto
+    - delivery-dashboard
+    - ghas
+    - malware-scanner
+    - osid
+    - prometheus-operator
+    - responsibles
+    - sast


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Adds the (bootstrapping) configuration and secrets for a public ODG demo instance as well as the respective deploy workflow. Due to the lack of configuration options to express an "any" subject in the authorisation configuration for the reader role, this first iteration will only grant read access to members of the `open-component-model` organisation. Once the upstream configuration allows configuration of an "any" subject, this configuration must be revisted.

#### Which issue(s) this PR is related to
Fixes https://github.com/open-component-model/open-delivery-gear/issues/9