### PR TITLE
fix(demo): Use sov ocm-repo for all relevant components

### DIFF
--- a/demo-cluster/bootstrapping/values.yaml.tpl
+++ b/demo-cluster/bootstrapping/values.yaml.tpl
@@ -364,7 +364,7 @@ ocm_repo_mappings:
       - opendesk.poc.sap.com
   - repository: ghcr.io/vasu1124
     prefixes:
-      - acme.org/sovereign/product
+      - acme.org/sovereign
 
 profiles:
   - name: OCM


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Otherwise the sovereign scenario OCM component tree cannot be resolved, due to prefix mismatch.

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->