### PR TITLE
chore: added issue templates for tasks and co

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,56 @@
+---
+name: Bug
+about: "🪲 Create a bug to help the projects improve"
+title: ''
+type: Bug
+
+---
+
+**Context**
+<!---
+Please provide a clear and concise description of the bug.
+-->
+
+**Version**
+<!---
+Please provide the version of the project are you using?
+- For ocm-cli, run `ocm --version`.
+- For ocm-controllers, check the image specified in your deployment.
+-->
+
+**To Reproduce**
+<!---
+Please provide steps to reproduce the behavior. Keep the description as 
+minimal and precisely as possible! 
+The listed information below is intended as guidance, please include only as 
+much as required to reproduce.
+
+- For the ocm-cli, provide information about
+  - the environment you are running on (OS, shell, etc.),
+  - the commands (including flags) you used,
+  - the relevant parts of your configuration file (default location `$HOME/.
+ocmconfig`). Be careful to redact any sensitive information.
+
+- For the ocm-controllers, provide information about
+  - the relevant kubernetes resource manifests
+  - the relevant ocm components and artifacts (an overview can be provided 
+    by `ocm get cv ... -r` and `ocm get resources ... -r`)
+  - the relevant controller logs
+  - the cluster infrastructure you are running on (like kind)
+  - the kubernetes/kro/flux version
+-->
+
+**Actual behavior**
+<!---
+Please provide a clear and concise description of what actually happened.
+-->
+
+**Expected behavior**
+<!---
+Please provide a clear and concise description of what you expected to happen.
+-->
+
+**Additional Comments**
+<!---
+Is there any other information we need to know about this bug?
+-->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,6 @@
 ---
 name: Bug
-about: "🪲 Create a bug to help the projects improve"
+about: "🪲 Create a bug to help the project improve"
 title: ''
 type: Bug
 
@@ -13,9 +13,11 @@ Please provide a clear and concise description of the bug.
 
 **Version**
 <!---
-Please provide the version of the project are you using?
-- For ocm-cli, run `ocm --version`.
-- For ocm-controllers, check the image specified in your deployment.
+Please provide the version of Open Delivery Gear you are using.
+- The overall ODG version (see the `./VERSION` file) is usually enough, as it
+  gives us the full version vector.
+- If known, you can also provide the individual `odg-core` and `odg-ui`
+  versions.
 -->
 
 **To Reproduce**
@@ -25,19 +27,13 @@ minimal and precisely as possible!
 The listed information below is intended as guidance, please include only as 
 much as required to reproduce.
 
-- For the ocm-cli, provide information about
-  - the environment you are running on (OS, shell, etc.),
-  - the commands (including flags) you used,
-  - the relevant parts of your configuration file (default location `$HOME/.
-ocmconfig`). Be careful to redact any sensitive information.
-
-- For the ocm-controllers, provide information about
-  - the relevant kubernetes resource manifests
-  - the relevant ocm components and artifacts (an overview can be provided 
-    by `ocm get cv ... -r` and `ocm get resources ... -r`)
-  - the relevant controller logs
-  - the cluster infrastructure you are running on (like kind)
-  - the kubernetes/kro/flux version
+- The environment you are running on (OS, shell, Kubernetes version,
+  cluster infrastructure such as kind, etc.).
+- The relevant parts of your ODG configuration, such as
+  `extensions_cfg.yaml` or `ocm_repo_mappings.yaml`, or the values of your
+  Helm chart. Be careful to redact any sensitive information.
+- The relevant OCM components and artifacts.
+- The relevant logs.
 -->
 
 **Actual behavior**

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -11,7 +11,10 @@ assignees: ''
 What is the goal of this epic?
 
 **User Story**
-As a DevOps admin, I want to ...
+
+- As a developer, I want to ... <!-- e.g. building or extending a scanner extension -->
+- As an operator, I want to ... <!-- e.g. deploying/configuring ODG in a cluster -->
+- As an end user, I want to ... <!-- e.g. working with findings in the Dashboard/API -->
 
 **Scope**
 List all deliverables that are part of this epic. The Epic is considered DONE if all of the below mentioned deliverables are available.
@@ -19,7 +22,7 @@ List all deliverables that are part of this epic. The Epic is considered DONE if
 - [ ] Function 1
 - [ ] Function 2
 - [ ] Tests
-- [ ] End user documentation
+- [ ] End-user documentation
 - [ ] Informed Community
 - [ ] ...
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,27 @@
+---
+name: Epic Template
+about: Template for a new Epic
+title: 'EPIC: '
+type: Epic
+assignees: ''
+
+---
+
+**Description**
+What is the goal of this epic?
+
+**User Story**
+As a DevOps admin, I want to ...
+
+**Scope**
+List all deliverables that are part of this epic. The Epic is considered DONE if all of the below mentioned deliverables are available.
+
+- [ ] Function 1
+- [ ] Function 2
+- [ ] Tests
+- [ ] End user documentation
+- [ ] Informed Community
+- [ ] ...
+
+**Out of Scope**
+List features or implementation strategies that shouldn't be considered in this iteration.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Suggest a feature
+title: ''
+type: Feature
+
+---
+
+**Description**
+<!---
+What would you like to be added?
+Why is this needed?
+-->
+

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -1,0 +1,20 @@
+---
+name: Task (Spike) / Backlog Item
+about: Create a Spike Task / Backlog Item to be worked on
+title: ''
+type: Spike
+assignees: ''
+
+---
+
+**Description**
+What is the goal of this spike?
+
+### Timebox: 1 day(s)
+
+**Done Criteria**
+
+- [ ] Estimation of impact on existing code incl. tests
+- [ ] Estimation of impact on Enduser Documentation updated (if applicable)
+- [ ] Estimation of impact on Internal technical Documentation created/updated (if applicable)
+- [ ] Created refinable tasks for the actual implementation

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -15,6 +15,6 @@ What is the goal of this spike?
 **Done Criteria**
 
 - [ ] Estimation of impact on existing code incl. tests
-- [ ] Estimation of impact on Enduser Documentation updated (if applicable)
-- [ ] Estimation of impact on Internal technical Documentation created/updated (if applicable)
+- [ ] Estimation of impact on End-user documentation (if applicable)
+- [ ] Estimation of impact on Internal technical documentation (if applicable)
 - [ ] Created refinable tasks for the actual implementation

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -13,7 +13,7 @@ assignees: ''
 
 - ...
 - Code has been reviewed by other team members
-- Analysis of existing tests (Unit and Integration)
-- Unit Tests created for new code or existing Unit Tests updated
-- End-user Documentation updated (if applicable)
-- Internal technical Documentation created/updated (if applicable)
+- Analysis of existing tests (unit and integration)
+- Unit tests created for new code or existing unit tests updated
+- End-user documentation updated (if applicable)
+- Internal technical documentation created/updated (if applicable)

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,19 @@
+---
+name: Task / Backlog Item
+about: Create a Task / Backlog Item to be worked on
+title: ''
+type: Task
+assignees: ''
+
+---
+
+**Description**
+
+**Done Criteria**
+
+- [ ] ...
+- [ ] Code has been reviewed by other team members
+- [ ] Analysis of existing tests (Unit and Integration)
+- [ ] Unit Tests created for new code or existing Unit Tests updated
+- [ ] End-user Documentation updated (if applicable)
+- [ ] Internal technical Documentation created/updated (if applicable)

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -16,4 +16,4 @@ assignees: ''
 - Analysis of existing tests (unit and integration)
 - Unit tests created for new code or existing unit tests updated
 - End-user documentation updated (if applicable)
-- Internal technical documentation created/updated (if applicable)
+- Technical documentation created/updated (if applicable)

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -11,9 +11,9 @@ assignees: ''
 
 **Done Criteria**
 
-- [ ] ...
-- [ ] Code has been reviewed by other team members
-- [ ] Analysis of existing tests (Unit and Integration)
-- [ ] Unit Tests created for new code or existing Unit Tests updated
-- [ ] End-user Documentation updated (if applicable)
-- [ ] Internal technical Documentation created/updated (if applicable)
+- ...
+- Code has been reviewed by other team members
+- Analysis of existing tests (Unit and Integration)
+- Unit Tests created for new code or existing Unit Tests updated
+- End-user Documentation updated (if applicable)
+- Internal technical Documentation created/updated (if applicable)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Besides bug and feature issue templates for ticket reporting we need templates for the backlog management, so for tasks, epics and initiatives. Copied over the templates from the ocm-project repo and adjusted the task criteria list